### PR TITLE
Update css grid property to stop content overflow on the content page

### DIFF
--- a/packages/docs/src/pages/docs/style.module.css
+++ b/packages/docs/src/pages/docs/style.module.css
@@ -5,7 +5,7 @@
 @media (min-width: 960px) {
   .wrapper {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     align-items: start;
   }
 }
@@ -63,7 +63,7 @@
   line-height: var(--ms-0);
 }
 
-.neighborLabel > svg {
+.neighborLabel>svg {
   margin-top: -0.4rem;
 }
 


### PR DESCRIPTION
The code block was overflowing on the content page (https://radishjs.com/docs/guides/content/) because of the long urls. Updating the CSS grid property to `auto minmax(0, 1fr)` should stop that.