### PR TITLE
Refactor front matter

### DIFF
--- a/packages/radish/package.json
+++ b/packages/radish/package.json
@@ -23,9 +23,7 @@
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
     "rehype-highlight": "^6.0.0",
-    "remark-frontmatter": "^4.0.1",
     "remark-gfm": "^3.0.1",
-    "remark-mdx-frontmatter": "^2.1.1",
     "toml": "^3.0.0",
     "ws": "^8.5.0"
   },

--- a/packages/radish/tsconfig.json
+++ b/packages/radish/tsconfig.json
@@ -6,5 +6,5 @@
     "allowJs": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "build"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2988,6 +2988,28 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+radish@^0.1.13:
+  version "0.1.26"
+  resolved "https://registry.yarnpkg.com/radish/-/radish-0.1.26.tgz#d0c9c8df159ea49a7ccb0cb618db5df638668b5d"
+  integrity sha512-k1UA5LsM/hbLu8ACsKhmK5NOBZCLCe2pzByh0NGyOKKDwS7/WBOGbl0R5qEBGE5fDopP1wZ/T7ahycMf0s3cCw==
+  dependencies:
+    "@mdx-js/mdx" "^2.1.5"
+    "@svgr/core" "^6.5.1"
+    esbuild "~0.15.15"
+    globby "^13.1.1"
+    gray-matter "^4.0.3"
+    js-yaml "^4.1.0"
+    lightningcss "^1.16.1"
+    react "^18.2.0"
+    react-dom "^18.2.0"
+    react-helmet-async "^1.3.0"
+    rehype-highlight "^6.0.0"
+    remark-frontmatter "^4.0.1"
+    remark-gfm "^3.0.1"
+    remark-mdx-frontmatter "^2.1.1"
+    toml "^3.0.0"
+    ws "^8.5.0"
+
 react-dom@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"


### PR DESCRIPTION
Refactors front matter parsing to only use `gray-matter`, rather than a combination of that and MDX plugins. It makes the front matter accessible within the Markdown by injecting `import` statements into the generated code, then hooking into esbuild to load the contents.

This should add support for `url` references within Markdown front matter, fixing https://github.com/jakelazaroff/radish/issues/5, and also support TOML delimited by `+++`.
