### PR TITLE
Don't copy service worker if the service worker is disabled

### DIFF
--- a/packages/radish/src/core/bundle.ts
+++ b/packages/radish/src/core/bundle.ts
@@ -142,8 +142,10 @@ export async function bundle(options: BundleOptions): Promise<boolean> {
     websocket: options.websocket
   });
   results.push(...renderResults);
-  const swResult = await buildServiceWorker(DEST, PREFIX);
-  results.push(swResult);
+  if (SERVICE_WORKER) {
+    const swResult = await buildServiceWorker(DEST, PREFIX);
+    results.push(swResult);
+  }
 
   const errors = results.filter(result => result.error);
   reportErrors(errors);


### PR DESCRIPTION
This is done for two reasons:

1. There's no license file/comment! It is therefore not possible to properly comply with the stated MIT license. For most of the output, this isn't a problem (Radish's boilerplate is the generic HTML boilerplate), but for the service worker, it's a problem.
2. Uploading the service worker is not necessary in a configuration where it will never be invoked.